### PR TITLE
Add support for "completed items"

### DIFF
--- a/src/app/todo-item/item.component.ts
+++ b/src/app/todo-item/item.component.ts
@@ -59,9 +59,7 @@ export class ItemComponent implements OnInit {
   }
 
   toggleCompleted() {
-    console.log('before: ' + this.item.completed);
     this.item.completed = !this.item.completed;
-    console.log('after: ' + this.item.completed);
   }
 
 }

--- a/src/app/todo-item/item.component.ts
+++ b/src/app/todo-item/item.component.ts
@@ -5,11 +5,13 @@ import { Component, OnInit, Input, EventEmitter, Output } from '@angular/core';
   template: `
     <div class="todo-item">
       <input class="todo-checkbox"
-             type="checkbox">
+             type="checkbox"
+             (click)="toggleCompleted()">
       
       <span class="todo-title"
             [hidden]="editing" 
-            (click)="editItem()">{{ item.title }}</span>
+            (click)="editItem()"
+            [class.completed]="item.completed">{{ item.title }}</span>
       
       <todo-input [hidden]="!editing"
                   [title]="item.title"
@@ -54,6 +56,12 @@ export class ItemComponent implements OnInit {
 
   cancelEdit() {
     this.editing = false;
+  }
+
+  toggleCompleted() {
+    console.log('before: ' + this.item.completed);
+    this.item.completed = !this.item.completed;
+    console.log('after: ' + this.item.completed);
   }
 
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -38,3 +38,6 @@ ol, ul {
 .btn:hover {
   background: lightslategrey;
 }
+.completed {
+  text-decoration: line-through;
+}


### PR DESCRIPTION
Clicking on the checkbox in an item toggles the "completed" class for the span, adding or removing a line-through in the text.
If a user updates the data, the item resets (to not "completed").